### PR TITLE
Update for SMP passive idle task

### DIFF
--- a/CORTEX_M0+_RP2040/Standard_smp/FreeRTOSConfig.h
+++ b/CORTEX_M0+_RP2040/Standard_smp/FreeRTOSConfig.h
@@ -131,7 +131,7 @@ to exclude the API function. */
 /* A header file that defines trace macro can be included here. */
 
 /* SMP Related config. */
-#define configUSE_MINIMAL_IDLE_HOOK             0
+#define configUSE_PASSIVE_IDLE_HOOK             0
 #define portSUPPORT_SMP                         1
 
 #endif /* FREERTOS_CONFIG_H */

--- a/XCORE.AI_xClang/RTOSDemo/src/FreeRTOSConfig.h
+++ b/XCORE.AI_xClang/RTOSDemo/src/FreeRTOSConfig.h
@@ -43,7 +43,7 @@ your application. */
 
 /* Hook function related definitions. */
 #define configUSE_IDLE_HOOK                     1
-#define configUSE_MINIMAL_IDLE_HOOK             1
+#define configUSE_PASSIVE_IDLE_HOOK             1
 #define configUSE_TICK_HOOK                     1
 #define configCHECK_FOR_STACK_OVERFLOW          0
 #define configUSE_MALLOC_FAILED_HOOK            1

--- a/XCORE.AI_xClang/RTOSDemo/src/test.c
+++ b/XCORE.AI_xClang/RTOSDemo/src/test.c
@@ -86,17 +86,16 @@ static void prvSetupHardware( int tile, chanend_t xTile0Chan, chanend_t xTile1Ch
 
 /*-----------------------------------------------------------*/
 
-void vApplicationGetIdleTaskMemory(StaticTask_t **ppxIdleTaskTCBBuffer,
+void vApplicationGetIdleTaskMemory( StaticTask_t **ppxIdleTaskTCBBuffer,
                                     StackType_t **ppxIdleTaskStackBuffer,
-                                    uint32_t *pulIdleTaskStackSize )
+                                    uint32_t *pulIdleTaskStackSize,
+                                    BaseType_t xCoreId )
 {
-	static StaticTask_t xIdleTaskTCB;
-	static StackType_t uxIdleTaskStack[ configMINIMAL_STACK_SIZE ];
+    static StaticTask_t xIdleTaskTCBs[ configNUMBER_OF_CORES ];
+    static StackType_t uxIdleTaskStacks[ configNUMBER_OF_CORES ][ configMINIMAL_STACK_SIZE ];
 
-    *ppxIdleTaskTCBBuffer = &xIdleTaskTCB;
-
-    *ppxIdleTaskStackBuffer = uxIdleTaskStack;
-
+    *ppxIdleTaskTCBBuffer = &( xIdleTaskTCBs[ xCoreId ] );
+    *ppxIdleTaskStackBuffer = &( uxIdleTaskStacks[ xCoreId ][ 0 ] );
     *pulIdleTaskStackSize = configMINIMAL_STACK_SIZE;
 }
 
@@ -648,7 +647,7 @@ void vApplicationStackOverflowHook( TaskHandle_t pxTask, char *pcTaskName )
 }
 /*-----------------------------------------------------------*/
 
-void vApplicationMinimalIdleHook( void )
+void vApplicationPassiveIdleHook( void )
 {
 	//TaskStatus_t status;
 	//vTaskGetInfo(NULL, &status, pdTRUE, eInvalid);


### PR DESCRIPTION
This PR should be merged after kernel pull request [#784](https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/784) is merged.

Description
-----------
Update the minimal idle task name
* Rename `configUSE_MINIMAL_IDLE_HOOK` to `configUSE_PASSIVE_IDLE_HOOK`
* Update `vApplicationGetIdleTaskMemory` prototype for SMP

Test Steps
-----------
Build and run with FreeRTOS-Kernel pull request #784 without problem.

Related Issue
-----------
https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/784


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
