### PR TITLE
Update passive idle task memory for XMOS AI core

### DIFF
--- a/XCORE.AI_xClang/RTOSDemo/src/test.c
+++ b/XCORE.AI_xClang/RTOSDemo/src/test.c
@@ -116,7 +116,7 @@ void vApplicationGetIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
         configASSERT( ppxIdleTaskTCBBuffer != NULL );
         configASSERT( ppxIdleTaskStackBuffer != NULL );
         configASSERT( pulIdleTaskStackSize != NULL );
-        configASSERT( ( xPassiveIdleTaskIndex > 0 ) && ( xPassiveIdleTaskIndex < ( configNUMBER_OF_CORES - 1 ) ) );
+        configASSERT( ( xPassiveIdleTaskIndex >= 0 ) && ( xPassiveIdleTaskIndex < ( configNUMBER_OF_CORES - 1 ) ) );
 
         *ppxIdleTaskTCBBuffer = &( xIdleTaskTCBs[ xPassiveIdleTaskIndex ] );
         *ppxIdleTaskStackBuffer = &( uxIdleTaskStacks[ xPassiveIdleTaskIndex ][ 0 ] );

--- a/XCORE.AI_xClang/RTOSDemo/src/test.c
+++ b/XCORE.AI_xClang/RTOSDemo/src/test.c
@@ -86,19 +86,35 @@ static void prvSetupHardware( int tile, chanend_t xTile0Chan, chanend_t xTile1Ch
 
 /*-----------------------------------------------------------*/
 
-void vApplicationGetIdleTaskMemory( StaticTask_t **ppxIdleTaskTCBBuffer,
-                                    StackType_t **ppxIdleTaskStackBuffer,
-                                    uint32_t *pulIdleTaskStackSize,
-                                    BaseType_t xCoreId )
+void vApplicationGetIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
+                                    StackType_t ** ppxIdleTaskStackBuffer,
+                                    uint32_t * pulIdleTaskStackSize )
 {
-    static StaticTask_t xIdleTaskTCBs[ configNUMBER_OF_CORES ];
-    static StackType_t uxIdleTaskStacks[ configNUMBER_OF_CORES ][ configMINIMAL_STACK_SIZE ];
+    static StaticTask_t xIdleTaskTCB;
+    static StackType_t uxIdleTaskStack[ configMINIMAL_STACK_SIZE ];
 
-    *ppxIdleTaskTCBBuffer = &( xIdleTaskTCBs[ xCoreId ] );
-    *ppxIdleTaskStackBuffer = &( uxIdleTaskStacks[ xCoreId ][ 0 ] );
+    *ppxIdleTaskTCBBuffer = &( xIdleTaskTCB );
+    *ppxIdleTaskStackBuffer = &( uxIdleTaskStack[ 0 ] );
     *pulIdleTaskStackSize = configMINIMAL_STACK_SIZE;
 }
+/*-----------------------------------------------------------*/
 
+#if ( configNUMBER_OF_CORES > 1 )
+
+    void vApplicationGetPassiveIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
+                                               StackType_t ** ppxIdleTaskStackBuffer,
+                                               uint32_t * pulIdleTaskStackSize,
+                                               BaseType_t xPassiveIdleTaskIndex )
+    {
+        static StaticTask_t xIdleTaskTCBs[ configNUMBER_OF_CORES - 1 ];
+        static StackType_t uxIdleTaskStacks[ configNUMBER_OF_CORES - 1 ][ configMINIMAL_STACK_SIZE ];
+
+        *ppxIdleTaskTCBBuffer = &( xIdleTaskTCBs[ xPassiveIdleTaskIndex ] );
+        *ppxIdleTaskStackBuffer = &( uxIdleTaskStacks[ xPassiveIdleTaskIndex ][ 0 ] );
+        *pulIdleTaskStackSize = configMINIMAL_STACK_SIZE;
+    }
+
+#endif /* #if ( configNUMBER_OF_CORES > 1 ) */
 /*-----------------------------------------------------------*/
 
 void vApplicationGetTimerTaskMemory(StaticTask_t **ppxTimerTaskTCBBuffer,

--- a/XCORE.AI_xClang/RTOSDemo/src/test.c
+++ b/XCORE.AI_xClang/RTOSDemo/src/test.c
@@ -93,6 +93,10 @@ void vApplicationGetIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
     static StaticTask_t xIdleTaskTCB;
     static StackType_t uxIdleTaskStack[ configMINIMAL_STACK_SIZE ];
 
+    configASSERT( ppxIdleTaskTCBBuffer != NULL );
+    configASSERT( ppxIdleTaskStackBuffer != NULL );
+    configASSERT( pulIdleTaskStackSize != NULL );
+
     *ppxIdleTaskTCBBuffer = &( xIdleTaskTCB );
     *ppxIdleTaskStackBuffer = &( uxIdleTaskStack[ 0 ] );
     *pulIdleTaskStackSize = configMINIMAL_STACK_SIZE;
@@ -108,6 +112,11 @@ void vApplicationGetIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
     {
         static StaticTask_t xIdleTaskTCBs[ configNUMBER_OF_CORES - 1 ];
         static StackType_t uxIdleTaskStacks[ configNUMBER_OF_CORES - 1 ][ configMINIMAL_STACK_SIZE ];
+
+        configASSERT( ppxIdleTaskTCBBuffer != NULL );
+        configASSERT( ppxIdleTaskStackBuffer != NULL );
+        configASSERT( pulIdleTaskStackSize != NULL );
+        configASSERT( ( xPassiveIdleTaskIndex > 0 ) && ( xPassiveIdleTaskIndex < ( configNUMBER_OF_CORES - 1 ) ) );
 
         *ppxIdleTaskTCBBuffer = &( xIdleTaskTCBs[ xPassiveIdleTaskIndex ] );
         *ppxIdleTaskStackBuffer = &( uxIdleTaskStacks[ xPassiveIdleTaskIndex ][ 0 ] );


### PR DESCRIPTION
Update passive idle task memory for XMOS AI core

Description
-----------
Update for 'vApplicationGetPassiveIdleTaskMemory'.

Test Steps
-----------
Before this PR, this demo build will fail.
```
xcc -c -MT"build/AbortDelay.c.o" -MMD -MP -MF"build/AbortDelay.c.d" -MT"build/AbortDelay.c.d" -o build/AbortDelay.c.o ../../../../Common/Minimal/AbortDelay.c -Wall -O2 -g -report -fxscope src/XCORE-AI-EXPLORER.xn src/config.xscope -Isrc -Isrc/IntQueueTimer -Isrc/regtest -I../../../../../Source/include -I../../../../../Source/portable/ThirdParty/xClang/XCOREAI -I../../../../Common/include -I../lib_rtos_support/api -I../lib_rtos_support/src
src/test.c:89:6: error: conflicting types for 'vApplicationGetIdleTaskMemory'
void vApplicationGetIdleTaskMemory( StaticTask_t **ppxIdleTaskTCBBuffer,
     ^
../../../../../Source/include\task.h:2000:10: note: previous declaration is here
    void vApplicationGetIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
```

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
