### PR TITLE
Fix RP2040 builds

### DIFF
--- a/CORTEX_M0+_RP2040/CMakeLists.txt
+++ b/CORTEX_M0+_RP2040/CMakeLists.txt
@@ -8,8 +8,6 @@ include(pico_sdk_import.cmake)
 
 PROJECT(examples)
 
-set( FREERTOS_KERNEL_PATH "../../../../../Source" )
-
 add_subdirectory(OnEitherCore)
 add_subdirectory(Standard)
 add_subdirectory(UsingCMSIS)

--- a/CORTEX_M0+_RP2040/README.md
+++ b/CORTEX_M0+_RP2040/README.md
@@ -11,6 +11,8 @@ The examples build as regular Raspberry Pi Pico SDK applications. You can build 
 
 See [Getting Started With Pico](https://datasheets.raspberrypi.org/pico/getting-started-with-pico.pdf) in the SDK documentation for setting up a Raspberry Pi Pico SDK build environment. If you are already set up, then just make sure `PICO_SDK_PATH` is set in your environment or pass it via `-DPICO_SDK_PATH=xxx` on the Cmake command line.
 
+The demos also depend on the `[FreeRTOS Demo](https://github.com/FreeRTOS/FreeRTOS/tree/main/FreeRTOS/Demo)` code found in the main FreeRTOS project. By default, the `FREERTOS_DEMO_PATH` will be computed from the `FREERTOS_KERNEL_PATH`. You can override this behavior by setting `FREERTOS_DEMO_PATH` in your environment or on the Cmake command line.
+
 To build from the command line on unix, from this directory (or from the individual examples' directories), type:
 
 ```shell

--- a/CORTEX_M0+_RP2040/Standard/CMakeLists.txt
+++ b/CORTEX_M0+_RP2040/Standard/CMakeLists.txt
@@ -6,6 +6,17 @@ include(pico_sdk_import.cmake)
 # Pull in FreeRTOS
 include(FreeRTOS_Kernel_import.cmake)
 
+if (NOT FREERTOS_DEMO_PATH)
+        if (DEFINED ENV{FREERTOS_DEMO_PATH})
+                set(FREERTOS_DEMO_PATH $ENV{FREERTOS_DEMO_PATH})
+                message("Using FREERTOS_DEMO_PATH from environment ('${FREERTOS_DEMO_PATH}')")
+        elseif(EXISTS ${FREERTOS_KERNEL_PATH}/../Demo)
+                set(FREERTOS_DEMO_PATH ${FREERTOS_KERNEL_PATH}/../Demo)
+        else ()
+                message(FATAL_ERROR "FreeRTOS demo path was not specified. Please set FREERTOS_DEMO_PATH.")
+        endif ()
+endif ()
+
 project(example C CXX ASM)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 17)
@@ -17,21 +28,21 @@ add_executable(main_full
         main_full.c
         IntQueueTimer.c
         RegTest.s
-        ../../../../Common/Minimal/blocktim.c
-        ../../../../Common/Minimal/countsem.c
-        ../../../../Common/Minimal/dynamic.c
-        ../../../../Common/Minimal/recmutex.c
-        ../../../../Common/Minimal/QueueOverwrite.c
-        ../../../../Common/Minimal/EventGroupsDemo.c
-        ../../../../Common/Minimal/IntSemTest.c
-        ../../../../Common/Minimal/IntQueue.c
-        ../../../../Common/Minimal/TaskNotify.c
-        ../../../../Common/Minimal/TimerDemo.c
-        ../../../../Common/Minimal/GenQTest.c
-        ../../../../Common/Minimal/death.c
-        ../../../../Common/Minimal/semtest.c
-        ../../../../Common/Minimal/BlockQ.c
-        ../../../../Common/Minimal/flop.c
+        ${FREERTOS_DEMO_PATH}/Common/Minimal/blocktim.c
+        ${FREERTOS_DEMO_PATH}/Common/Minimal/countsem.c
+        ${FREERTOS_DEMO_PATH}/Common/Minimal/dynamic.c
+        ${FREERTOS_DEMO_PATH}/Common/Minimal/recmutex.c
+        ${FREERTOS_DEMO_PATH}/Common/Minimal/QueueOverwrite.c
+        ${FREERTOS_DEMO_PATH}/Common/Minimal/EventGroupsDemo.c
+        ${FREERTOS_DEMO_PATH}/Common/Minimal/IntSemTest.c
+        ${FREERTOS_DEMO_PATH}/Common/Minimal/IntQueue.c
+        ${FREERTOS_DEMO_PATH}/Common/Minimal/TaskNotify.c
+        ${FREERTOS_DEMO_PATH}/Common/Minimal/TimerDemo.c
+        ${FREERTOS_DEMO_PATH}/Common/Minimal/GenQTest.c
+        ${FREERTOS_DEMO_PATH}/Common/Minimal/death.c
+        ${FREERTOS_DEMO_PATH}/Common/Minimal/semtest.c
+        ${FREERTOS_DEMO_PATH}/Common/Minimal/BlockQ.c
+        ${FREERTOS_DEMO_PATH}/Common/Minimal/flop.c
         )
 
 target_compile_definitions(main_full PRIVATE
@@ -40,7 +51,7 @@ target_compile_definitions(main_full PRIVATE
 
 target_include_directories(main_full PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}
-        ${CMAKE_CURRENT_LIST_DIR}/../../../../Common/include)
+        ${FREERTOS_DEMO_PATH}/Common/include)
 
 target_compile_definitions(main_full PRIVATE
         PICO_STDIO_STACK_BUFFER_SIZE=64 # use a small printf on stack buffer
@@ -71,7 +82,7 @@ target_compile_definitions(main_blinky PRIVATE
 
 target_include_directories(main_blinky PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}
-        ${CMAKE_CURRENT_LIST_DIR}/../../../../Common/include)
+        ${FREERTOS_DEMO_PATH}/Common/include)
 
 target_link_libraries(main_blinky pico_stdlib FreeRTOS-Kernel FreeRTOS-Kernel-Heap1)
 pico_add_extra_outputs(main_blinky)

--- a/CORTEX_M0+_RP2040/Standard_smp/CMakeLists.txt
+++ b/CORTEX_M0+_RP2040/Standard_smp/CMakeLists.txt
@@ -6,6 +6,17 @@ include(pico_sdk_import.cmake)
 # Pull in FreeRTOS
 include(FreeRTOS_Kernel_import.cmake)
 
+if (NOT FREERTOS_DEMO_PATH)
+        if (DEFINED ENV{FREERTOS_DEMO_PATH})
+                set(FREERTOS_DEMO_PATH $ENV{FREERTOS_DEMO_PATH})
+                message("Using FREERTOS_DEMO_PATH from environment ('${FREERTOS_DEMO_PATH}')")
+        elseif(EXISTS ${FREERTOS_KERNEL_PATH}/../Demo)
+                set(FREERTOS_DEMO_PATH ${FREERTOS_KERNEL_PATH}/../Demo)
+        else ()
+                message(FATAL_ERROR "FreeRTOS demo path was not specified. Please set FREERTOS_DEMO_PATH.")
+        endif ()
+endif ()
+
 project(example C CXX ASM)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 17)
@@ -17,21 +28,21 @@ add_executable(main_full_smp
         main_full.c
         IntQueueTimer.c
         RegTest.s
-        ../../../../Common/Minimal/blocktim.c
-        ../../../../Common/Minimal/countsem.c
-        ../../../../Common/Minimal/dynamic.c
-        ../../../../Common/Minimal/recmutex.c
-        ../../../../Common/Minimal/QueueOverwrite.c
-        ../../../../Common/Minimal/EventGroupsDemo.c
-        ../../../../Common/Minimal/IntSemTest.c
-        ../../../../Common/Minimal/IntQueue.c
-        ../../../../Common/Minimal/TaskNotify.c
-        ../../../../Common/Minimal/TimerDemo.c
-        ../../../../Common/Minimal/GenQTest.c
-        ../../../../Common/Minimal/death.c
-        ../../../../Common/Minimal/semtest.c
-        ../../../../Common/Minimal/BlockQ.c
-        ../../../../Common/Minimal/flop.c
+        ${FREERTOS_DEMO_PATH}/Common/Minimal/blocktim.c
+        ${FREERTOS_DEMO_PATH}/Common/Minimal/countsem.c
+        ${FREERTOS_DEMO_PATH}/Common/Minimal/dynamic.c
+        ${FREERTOS_DEMO_PATH}/Common/Minimal/recmutex.c
+        ${FREERTOS_DEMO_PATH}/Common/Minimal/QueueOverwrite.c
+        ${FREERTOS_DEMO_PATH}/Common/Minimal/EventGroupsDemo.c
+        ${FREERTOS_DEMO_PATH}/Common/Minimal/IntSemTest.c
+        ${FREERTOS_DEMO_PATH}/Common/Minimal/IntQueue.c
+        ${FREERTOS_DEMO_PATH}/Common/Minimal/TaskNotify.c
+        ${FREERTOS_DEMO_PATH}/Common/Minimal/TimerDemo.c
+        ${FREERTOS_DEMO_PATH}/Common/Minimal/GenQTest.c
+        ${FREERTOS_DEMO_PATH}/Common/Minimal/death.c
+        ${FREERTOS_DEMO_PATH}/Common/Minimal/semtest.c
+        ${FREERTOS_DEMO_PATH}/Common/Minimal/BlockQ.c
+        ${FREERTOS_DEMO_PATH}/Common/Minimal/flop.c
         )
 
 target_compile_definitions(main_full_smp PRIVATE
@@ -40,7 +51,7 @@ target_compile_definitions(main_full_smp PRIVATE
 
 target_include_directories(main_full_smp PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}
-        ${CMAKE_CURRENT_LIST_DIR}/../../../../Common/include)
+        ${FREERTOS_DEMO_PATH}/Common/include)
 
 target_compile_definitions(main_full_smp PRIVATE
         PICO_STDIO_STACK_BUFFER_SIZE=64 # use a small printf on stack buffer
@@ -74,7 +85,7 @@ target_compile_options( main_blinky_smp PUBLIC
 
 target_include_directories(main_blinky_smp PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}
-        ${CMAKE_CURRENT_LIST_DIR}/../../../../Common/include)
+        ${FREERTOS_DEMO_PATH}/Common/include)
 
 target_link_libraries(main_blinky_smp pico_stdlib FreeRTOS-Kernel FreeRTOS-Kernel-Heap1)
 pico_add_extra_outputs(main_blinky_smp)

--- a/CORTEX_M0+_RP2040/UsingCMSIS/CMakeLists.txt
+++ b/CORTEX_M0+_RP2040/UsingCMSIS/CMakeLists.txt
@@ -18,7 +18,7 @@ target_include_directories(using_cmsis PUBLIC
         ${CMAKE_CURRENT_LIST_DIR}
         )
 
-target_compile_options( on_core_one PUBLIC
+target_compile_options( using_cmsis PUBLIC
         ### Gnu/Clang C Options
         $<$<COMPILE_LANG_AND_ID:C,GNU>:-fdiagnostics-color=always>
         $<$<COMPILE_LANG_AND_ID:C,Clang>:-fcolor-diagnostics>

--- a/CORTEX_M0+_RP2040/UsingCMSIS/main.c
+++ b/CORTEX_M0+_RP2040/UsingCMSIS/main.c
@@ -27,8 +27,6 @@ static void prvMainTask( void *pvParameters );
 static void prvBlinkTask( void *pvParameters );
 
 int main(void) {
-    TimerHandle_t xExampleSoftwareTimer = NULL;
-
     /* Configure the system ready to run the demo.  The clock configuration
     can be done here if it was not done before main() was called. */
     prvSetupHardware();
@@ -79,7 +77,7 @@ int main(void) {
 }
 /*-----------------------------------------------------------*/
 
-static void prvBlinkTask( void *pvParameters )
+static void prvBlinkTask()
 {
     for( ;; )
     {
@@ -89,7 +87,7 @@ static void prvBlinkTask( void *pvParameters )
 }
 
 #include "hardware/irq.h"
-static void prvMainTask( void *pvParameters )
+static void prvMainTask()
 {
     for( ;; )
     {

--- a/CORTEX_M0+_RP2040/UsingCMSIS/main.c
+++ b/CORTEX_M0+_RP2040/UsingCMSIS/main.c
@@ -77,8 +77,10 @@ int main(void) {
 }
 /*-----------------------------------------------------------*/
 
-static void prvBlinkTask()
+static void prvBlinkTask( void *pvParameters )
 {
+    ( void ) pvParameters;
+    
     for( ;; )
     {
         vTaskDelay(pdMS_TO_TICKS( 500 ));
@@ -87,8 +89,10 @@ static void prvBlinkTask()
 }
 
 #include "hardware/irq.h"
-static void prvMainTask()
+static void prvMainTask( void *pvParameters )
 {
+    ( void ) pvParameters;
+
     for( ;; )
     {
         vTaskDelay(pdMS_TO_TICKS( 3000 ));


### PR DESCRIPTION
<!--- Title -->
Fix RP2040 demo builds.

Description
-----------
<!--- Describe your changes in detail. -->
The CMake files assume that the FreeRTOS demo code is at a specific relative path. However, since this code is contained in a different git repo, it is not safe to assume that the code is at a specific relative path on the local system. If the files are not arranged just right, it will cause the builds to fail.

Test Steps
-----------
Build the RP2040 demos.

Related Issue
-----------
None


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
