### PR TITLE
Fix build failure

### DIFF
--- a/CORTEX_M0+_RP2040/Standard_smp/FreeRTOSConfig.h
+++ b/CORTEX_M0+_RP2040/Standard_smp/FreeRTOSConfig.h
@@ -100,6 +100,7 @@
 #define configNUMBER_OF_CORES                   2
 #define configTICK_CORE                         0
 #define configRUN_MULTIPLE_PRIORITIES           0
+#define configUSE_CORE_AFFINITY                 1
 
 /* RP2040 specific */
 #define configSUPPORT_PICO_SYNC_INTEROP         1


### PR DESCRIPTION
Description
-----------
The file flash.c in pico-sdk now requires `configUSE_CORE_AFFINITY` to be defined for SMP.

Test Steps
-----------
```
git clone https://github.com/raspberrypi/pico-sdk.git
cmake -B build -DPICO_SDK_PATH=pico-sdk -GNinja
ninja -C build --verbose
```

Related Issue
-----------
NA.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
